### PR TITLE
Added parenthesis to print

### DIFF
--- a/germline/buildBrowserGermline.py
+++ b/germline/buildBrowserGermline.py
@@ -5,7 +5,7 @@ import time
 
     
 if len(sys.argv) < 3:
-    print "Usage: %s <FASTA input file> [JSON/DATA germline file] [JSON output file]" % sys.argv[0]
+    print("Usage: %s <FASTA input file> [JSON/DATA germline file] [JSON output file]" % sys.argv[0])
     sys.exit()
 input_name = sys.argv[1]
 output_name = ""

--- a/germline/split-from-imgt.py
+++ b/germline/split-from-imgt.py
@@ -14,7 +14,7 @@ IMGT_LICENSE = '''
    # Nucl. Acids Res., 29, 207-209 (2001). PMID: 11125093
 '''
 
-print IMGT_LICENSE
+print (IMGT_LICENSE)
 
 
 # Parse lines in IMGT/GENE-DB such as:
@@ -24,7 +24,7 @@ open_files = {}
 current_file = None
 
 def verbose_open_w(name):
-    print " ==> %s" % name
+    print (" ==> %s" % name)
     return open(name, 'w')
 
 def get_split_files(seq, split_seq):


### PR DESCRIPTION
Both python 2 and python3 support the use of print as a function (i.e. with parentheses) but parentheses are required for python3 compatibility so I added them on line 8 of germline/buildBrowserGermline.py and lines 17 and 27 of germline/split-from-imgt.py.